### PR TITLE
Fill parameter which can be guess automatically

### DIFF
--- a/controllers/notice.rb
+++ b/controllers/notice.rb
@@ -38,7 +38,7 @@ class NoticeRoutes < Sinatra::Base
     halt 403 if not Notice.allowed_to_create_by?(current_user)
 
     @attrs = params_to_attributes_of(klass: Notice)
-    @attrs[:member_id] = current_user.id if not is_admin?
+    @attrs[:member_id] = current_user.id if (not is_admin?) || @attrs[:member_id].nil?
     @notice = Notice.new(@attrs)
 
     if @notice.save

--- a/controllers/score.rb
+++ b/controllers/score.rb
@@ -64,7 +64,7 @@ class ScoreRoutes < Sinatra::Base
     halt 403 if not Score.allowed_to_create_by?(current_user)
 
     @attrs = params_to_attributes_of(klass: Score)
-    @attrs[:marker_id] = current_user.id if not is_admin?
+    @attrs[:marker_id] = current_user.id if (not is_admin?) || @attrs[:marker_id].nil?
     @score = Score.new(@attrs)
 
     if @score.save
@@ -130,7 +130,7 @@ class ScoreRoutes < Sinatra::Base
     halt 403 if not Score.allowed_to_create_by?(current_user)
 
     @attrs = params_to_attributes_of(klass: Score)
-    @attrs[:marker_id] = current_user.id if not is_admin?
+    @attrs[:marker_id] = current_user.id if (not is_admin?) || @attrs[:marker_id].nil?
     @attrs[:answer_id] = @answer.id
     @score = Score.new(@attrs)
 


### PR DESCRIPTION
Fill member_id / marker_id  automatically by admin’s request when it's nil.

Current UI implementation expects it though API doesn't.  This fixes it.