### PR TITLE
Add problem_ids attribute in problem_groups

### DIFF
--- a/controllers/problem_group.rb
+++ b/controllers/problem_group.rb
@@ -12,10 +12,11 @@ class ProblemGroupRoutes < Sinatra::Base
     I18n.locale = :en if request.xhr?
 
     @with_param = (params[:with] || "").split(?,) & %w(problems) if request.get?
+    @as_option = { methods: [:problem_ids] }
   end
 
   get "/api/problem_groups" do
-    @problem_groups = generate_nested_hash(klass: ProblemGroup, by: current_user, params: @with_param, apply_filter: !(is_admin? || is_viewer?))
+    @problem_groups = generate_nested_hash(klass: ProblemGroup, by: current_user, as_option: @as_option, params: @with_param, apply_filter: !(is_admin? || is_viewer?))
     json @problem_groups
   end
 
@@ -25,7 +26,7 @@ class ProblemGroupRoutes < Sinatra::Base
   end
 
   get "/api/problem_groups/:id" do
-    @problem_group = generate_nested_hash(klass: ProblemGroup, by: current_user, params: @with_param, id: params[:id], apply_filter: !(is_admin? || is_viewer?))
+    @problem_group = generate_nested_hash(klass: ProblemGroup, by: current_user, as_option: @as_option, params: @with_param, id: params[:id], apply_filter: !(is_admin? || is_viewer?))
     json @problem_group
   end
 

--- a/spec/requests/problem_group_spec.rb
+++ b/spec/requests/problem_group_spec.rb
@@ -30,6 +30,17 @@ describe ProblemGroup do
         by_writer      { is_expected.to eq 2 }
         by_admin       { is_expected.to eq 2 }
       end
+
+      let(:expected_keys) { %w(id description name problem_ids completing_bonus_point flag_icon_url visible created_at updated_at) }
+      describe '#keys for problem_groups' do
+        let(:json_response_problem) { json_response.first }
+        subject { json_response_problem.keys }
+
+        by_viewer      { is_expected.to match_array expected_keys }
+        by_participant { is_expected.to match_array expected_keys }
+        by_writer      { is_expected.to match_array expected_keys }
+        by_admin       { is_expected.to match_array expected_keys }
+      end
     end
 
     describe 'before start competition' do
@@ -77,6 +88,16 @@ describe ProblemGroup do
       by_participant { is_expected.to eq 200 }
       by_writer      { is_expected.to eq 200 }
       by_admin       { is_expected.to eq 200 }
+
+      describe '#keys' do
+       let(:expected_keys) { %w(id description name problem_ids completing_bonus_point flag_icon_url visible created_at updated_at) }
+        subject { json_response.keys }
+
+        by_viewer      { is_expected.to match_array expected_keys }
+        by_participant { is_expected.to match_array expected_keys }
+        by_writer      { is_expected.to match_array expected_keys }
+        by_admin       { is_expected.to match_array expected_keys }
+      end
     end
 
     describe 'before start competition' do


### PR DESCRIPTION
Add an array, `problem_ids` attribute to following endpoint: `/api/problem_groups`, `/api/problem_groups/:id`