### PR TITLE
問題・グループの追加画面の修正

### DIFF
--- a/ui2/src/components/MessageBox.vue
+++ b/ui2/src/components/MessageBox.vue
@@ -24,6 +24,10 @@
 </template>
 
 <style scoped>
+.modal {
+  overflow-y: auto;
+}
+
 .modal.show {
   display: block;
   position: absolute;


### PR DESCRIPTION
・問題数が少ない場合にモーダルウィンドウの一部が切り取られ、追加のボタンが押せない問題を修正