### PR TITLE
Improve / Fix UI

### DIFF
--- a/ui2/src/App.vue
+++ b/ui2/src/App.vue
@@ -36,7 +36,7 @@ import Notif from './components/Notif'
 import { Emit, PUSH_NOTIF, Subscribe, AUTH_ERROR } from './utils/EventBus'
 import { API } from './utils/Api'
 import { mapGetters } from 'vuex'
-import { SET_SESSION } from './store/'
+import { RELOAD_CONTEST, SET_SESSION } from './store/'
 
 
 export default {
@@ -66,6 +66,7 @@ export default {
   },
   mounted () {
     this.reloadSession();
+    this.$store.dispatch(RELOAD_CONTEST);
   },
   beforeDestroy () {
     this.authError.off();

--- a/ui2/src/components/Answer.vue
+++ b/ui2/src/components/Answer.vue
@@ -22,7 +22,8 @@
           <div v-if="value.score" class="result">
             得点: {{ value.score.point }} + ボーナス: {{ value.score.bonus_point }}
           </div>
-          <div v-if="!value.score" class="pending">採点依頼中...</div>
+          <div v-if="!value.score && !isAdmin && isContestEnded" class="pending">競技時間が終了したため表示されません</div>
+          <div v-if="!value.score && (isAdmin || !isContestEnded)" class="pending">採点依頼中...</div>
         </template>
       </div>
     </div>
@@ -84,6 +85,7 @@ export default {
     return {
       post: '',
       newPoint: undefined,
+      now: new Date(),
     }
   },
   asyncData: {
@@ -92,7 +94,12 @@ export default {
     issueId () {
       return this.value.id;
     },
+    isContestEnded () {
+      if (!this.contest || !this.contest.competition_end_at) return false;
+      return new Date(this.contest.competition_end_at) <= this.now;
+    },
     ...mapGetters([
+      'contest',
       'isAdmin',
     ]),
   },
@@ -103,8 +110,10 @@ export default {
   },
   mounted () {
     this.newPoint = (this.value.score && this.value.score.point) || 0;
+    this.interval_id = setInterval(() => { this.now = new Date() }, 1000);
   },
   destroyed () {
+    clearInterval(this.interval_id);
   },
   methods: {
     submitPoint () {

--- a/ui2/src/components/InfoPanel.vue
+++ b/ui2/src/components/InfoPanel.vue
@@ -49,10 +49,6 @@ export default {
     problems () {
       return API.getProblemsWithScore();
     },
-    contestDefault: {},
-    contest () {
-      return API.getContest();
-    },
   },
   computed: {
     limit () {
@@ -67,6 +63,7 @@ export default {
       return d3.format('.3%')(this.scoredPurePoint / this.sumPurePoint);
     },
     ...mapGetters([
+      'contest',
       'isMember',
     ]),
   },

--- a/ui2/src/components/Notif.vue
+++ b/ui2/src/components/Notif.vue
@@ -151,13 +151,10 @@ export default {
     }
   },
   asyncData: {
-    contentDefault: {},
-    contest () {
-      return API.getContest();
-    },
   },
   computed: {
     ...mapGetters([
+      'contest',
       'session',
     ]),
   },

--- a/ui2/src/pages/Dashboard.vue
+++ b/ui2/src/pages/Dashboard.vue
@@ -103,10 +103,6 @@ export default {
     }
   },
   asyncData: {
-    sessionDefault: {},
-    session () {
-      return API.getSession();
-    },
     noticesDefault: [],
     notices () {
       return API.getNotices();
@@ -125,6 +121,7 @@ export default {
       return this.notifications.filter((v, i) => i < 15)
     },
     ...mapGetters([
+      'session',
       'isAdmin',
     ]),
   },

--- a/ui2/src/pages/ProblemAnswers.vue
+++ b/ui2/src/pages/ProblemAnswers.vue
@@ -160,10 +160,6 @@ export default {
     answers () {
       return API.getTeamWithAnswersComments(this.teamId).then(res => res.answers)
     },
-    contentDefault: {},
-    contest () {
-      return API.getContest();
-    },
   },
   computed: {
     problemId () {
@@ -199,6 +195,7 @@ export default {
         .reduce((p, n) => Math.max(p, new Date(n.created_at).valueOf() + this.delay), 0)
     },
     ...mapGetters([
+      'contest',
       'isAdmin',
     ])
   },

--- a/ui2/src/pages/Problems.vue
+++ b/ui2/src/pages/Problems.vue
@@ -451,10 +451,6 @@ export default {
     issues () {
       return API.getIssues();
     },
-    contentDefault: {},
-    contest () {
-      return API.getContest();
-    }
   },
   computed: {
     problemSelect () {
@@ -464,6 +460,7 @@ export default {
       }], this.problems);
     },
     ...mapGetters([
+      'contest',
       'isAdmin',
       'isMember',
       'session',

--- a/ui2/src/pages/Signup.vue
+++ b/ui2/src/pages/Signup.vue
@@ -83,6 +83,7 @@ export default {
           detail: '',
           key: 'login',
         });
+        this.$router.push({ name: 'login' })
       } catch (err) {
         console.error(err);
         Emit(PUSH_NOTIF, {

--- a/ui2/src/store/index.js
+++ b/ui2/src/store/index.js
@@ -1,8 +1,10 @@
 export {
+  SET_CONTEST,
+  RELOAD_CONTEST,
   SET_TITLE,
   RELOAD_SESSION,
   SET_SESSION,
-  CLEAR_SESSION
+  CLEAR_SESSION,
 } from './stores'
 
 export { default as DefaultStore } from './stores'

--- a/ui2/src/store/stores.js
+++ b/ui2/src/store/stores.js
@@ -3,6 +3,8 @@ import Vuex from 'vuex'
 
 import { API } from '../utils/Api'
 
+export const SET_CONTEST = 'SET_CONTEST';
+export const RELOAD_CONTEST = 'RELOAD_CONTEST';
 // ページのタイトルを設定する
 export const SET_TITLE = 'SET_TITLE';
 export const _SET_STATE_TITLE = '_SET_STATE_TITLE';
@@ -14,12 +16,14 @@ Vue.use(Vuex)
 
 export default new Vuex.Store({
   state: {
+    contest: {},
     title: '',
     session: {
       member: {}
     },
   },
   getters: {
+    contest: state => state.contest,
     title: state => state.title,
     session: state => state.session,
     isAdmin: state => {
@@ -40,6 +44,7 @@ export default new Vuex.Store({
     },
   },
   mutations: {
+    [SET_CONTEST]: (state, contest) => { state.contest = contest },
     [_SET_STATE_TITLE]: (state, title) => { state.title = title },
     [SET_SESSION]: (state, session) => { state.session = session },
     [CLEAR_SESSION]: (state) => { state.session = { member: {} } },
@@ -53,6 +58,12 @@ export default new Vuex.Store({
       API.getSession()
         .then(res => {
           ctx.commit(SET_SESSION, res)
+        })
+    },
+    [RELOAD_CONTEST]: (ctx) => {
+      API.getContest()
+        .then(res => {
+          ctx.commit(SET_CONTEST, res)
         })
     }
   },

--- a/ui2/src/store/stores.js
+++ b/ui2/src/store/stores.js
@@ -10,7 +10,6 @@ export const RELOAD_SESSION = 'RELOAD_SESSION'
 export const SET_SESSION = 'SET_SESSION'
 export const CLEAR_SESSION = 'CLEAR_SESSION'
 
-
 Vue.use(Vuex)
 
 export default new Vuex.Store({
@@ -53,7 +52,7 @@ export default new Vuex.Store({
     [RELOAD_SESSION]: (ctx) => {
       API.getSession()
         .then(res => {
-          ctx.commit(SET_SESSION)
+          ctx.commit(SET_SESSION, res)
         })
     }
   },


### PR DESCRIPTION
- `/api/contest` のコンテンツは変化しないので、1度だけ読み込んだあとはストアから参照するようにした
- `/api/session` に関する無駄なリクエストの削減
- サインアップ後にログインページへ遷移するようにした
- 解答一覧ページにおいて、未採点の場合のメッセージを修正
  - コンテスト時間終了後も "採点依頼中……" となっていたのを、コンテスト終了後であることを示す文言へ変更