### PR TITLE
Reduce api requests

### DIFF
--- a/ui2/src/components/Problem.vue
+++ b/ui2/src/components/Problem.vue
@@ -44,7 +44,7 @@
           基準点: {{ problem.reference_point }} /
           満点: {{ problem.perfect_point }} /
           通過チーム数: {{ problem.solved_teams_count }} /
-          依存: {{ dependenceProblem.title }}
+          依存: {{ dependenceProblemTitle }}
         </template>
       </div>
     </header>
@@ -134,16 +134,23 @@ export default {
     return {
       edit: false,
       newComment: '',
+      dependenceProblemTitle: {},
+      problems: [],
     }
   },
   asyncData: {
     problemDefault: {},
     problem () {
-      return API.getProblem(this.id);
-    },
-    problemsDefault: [],
-    problems () {
-      return API.getProblems();
+      return API.getProblem(this.id)
+        .then(res => {
+          // retrieve dependence problem
+          if (res.problem_must_solve_before_id) {
+            API.getProblem(res.problem_must_solve_before_id).then(res => { this.dependenceProblemTitle = res.title });
+          } else {
+            this.dependenceProblemTitle = 'なし';
+          }
+          return res;
+        });
     },
   },
   computed: {
@@ -152,10 +159,6 @@ export default {
         id: null,
         title: 'Null',
       }], this.problems);
-    },
-    dependenceProblem () {
-      return this.problems.find(p => p.id === this.problem.problem_must_solve_before_id) ||
-        { title: 'なし' };
     },
     ...mapGetters([
       'isAdmin',
@@ -167,6 +170,11 @@ export default {
         this.asyncReload();
       }
     },
+    edit (val, old) {
+      if (val) {
+        API.getProblems.then(res => { this.problems = res; });
+      }
+    }
   },
   mounted () {
     this.$store.dispatch(SET_TITLE, 'ページ名');

--- a/ui2/src/pages/ProblemDetail.vue
+++ b/ui2/src/pages/ProblemDetail.vue
@@ -35,8 +35,7 @@ export default {
   },
   mounted () {
     this.$store.dispatch(SET_TITLE, '問題詳細');
-    console.log(this.session);
-    if (this.session.member && this.session.member.team_id !== null) {
+    if (this.session.member && this.session.member.team_id) {
       this.$router.replace({
         name: 'problem-issues',
         params: {

--- a/ui2/src/pages/Problems.vue
+++ b/ui2/src/pages/Problems.vue
@@ -432,7 +432,6 @@ export default {
     },
     problemsDefault: [],
     problems () {
-      console.log('problems', this.session, this.isMember)
       if (this.session.member) {
         if (this.isMember) {
           return API.getProblemsWithScore();
@@ -442,14 +441,6 @@ export default {
       } else {
         return new Promise((resolve) => resolve([]));
       }
-    },
-    answersDefault: [],
-    answers () {
-      return API.getAnswers();
-    },
-    issuesDefault: [],
-    issues () {
-      return API.getIssues();
     },
   },
   computed: {
@@ -483,16 +474,6 @@ export default {
   destroyed () {
   },
   methods: {
-    answerCount (problemId) {
-      return this.answers
-        .filter(a => a.problem_id === problemId)
-        .reduce((p, n) => p + 1, 0);
-    },
-    issueCount (problemId) {
-      return this.issues
-        .filter(a => a.problem_id === problemId)
-        .reduce((p, n) => p + 1, 0);
-    },
     scoringStatusText (problem) {
       if (problem.title === undefined) {
         return '解答不可'
@@ -546,7 +527,6 @@ export default {
       return pg.flag_icon_url;
     },
     async addProblem () {
-      // console.log(this.newProblemObj);
       try {
         Emit(REMOVE_NOTIF, msg => msg.key === 'problem');
         await API.postProblems(this.newProblemObj);


### PR DESCRIPTION
- In problem-detail page, GET /api/problems only if admin tried to edit problem, improve dependence problem retrieving
- Remove unused data retrieving
- Fix unexpected redirect to problem-issues page when opening `/#/problems/:id` by not participant