### PR TITLE
redis-storeのバージョン更新

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,12 +58,12 @@ GEM
     rake (12.0.0)
     rblineprof (0.3.7)
       debugger-ruby_core_source (~> 1.3)
-    redis (3.3.3)
-    redis-rack (2.0.2)
+    redis (4.0.1)
+    redis-rack (2.0.3)
       rack (>= 1.5, < 3)
-      redis-store (>= 1.2, < 1.4)
-    redis-store (1.3.0)
-      redis (>= 2.2)
+      redis-store (>= 1.2, < 2)
+    redis-store (1.4.1)
+      redis (>= 2.2, < 5)
     rspec (3.6.0)
       rspec-core (~> 3.6.0)
       rspec-expectations (~> 3.6.0)
@@ -134,4 +134,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   1.15.3
+   1.16.0


### PR DESCRIPTION
GitHubからredis-storeのバージョンを上げろとメールが来たらしい

> We found a potential security vulnerability in one of the dependencies used by a repository that you contribute to.
> @ictsc    ictsc/ictsc-score-server
> Known high severity security vulnerability detected in redis-store < 1.4.0 defined in Gemfile.lock.
> Gemfile.lock update suggested: redis-store ~> 1.4.0

とりあえず、`bundle update redis-store` でバージョンを上げてインストールされるredis-storeを1.4以上にした