### PR TITLE
memberの情報を取得する際にundefinedだった場合の対策を追加

### DIFF
--- a/ui2/src/components/Issue.vue
+++ b/ui2/src/components/Issue.vue
@@ -21,7 +21,6 @@
           <router-link :to="{name: 'problem-issues', params: {id: '' + value.problem_id, team: '' + value.team_id, issue: '' + value.id}}">
             <h3>{{ value.title }}</h3>
           </router-link>
-          <!--<pre>{{ value }}</pre>-->
           <markdown :value="firstComment.text"></markdown>
         </div>
       </div>
@@ -30,8 +29,7 @@
       </div>
     </div>
     <div class="tail">
-      <!-- <div v-for="item in tailComment" class="item" :class="{ admin: item.member.role_id != 4 }"> -->
-      <div v-for="item in tailComment" class="item">
+      <div v-for="item in tailComment" class="item" :class="{ admin: !item.member || item.member.role_id != 4 }">
         <p>{{ item.member }}</p>
         <div class="comment">
           <markdown :value="item.text"></markdown>

--- a/ui2/src/components/Issue.vue
+++ b/ui2/src/components/Issue.vue
@@ -30,11 +30,18 @@
       </div>
     </div>
     <div class="tail">
-      <div v-for="item in tailComment" class="item" :class="{ admin: item.member.role_id != 4 }">
+      <!-- <div v-for="item in tailComment" class="item" :class="{ admin: item.member.role_id != 4 }"> -->
+      <div v-for="item in tailComment" class="item">
+        <p>{{ item.member }}</p>
         <div class="comment">
           <markdown :value="item.text"></markdown>
         </div>
-        <div class="meta">投稿者: {{ item.member.name }} | {{ item.created_at }}</div>
+        <template v-if="item.member">
+          <div class="meta">投稿者: {{ item.member.name }} | {{ item.created_at }}</div>
+        </template>
+        <template v-else>
+          <div class="meta">投稿者: ICTSC | {{ item.created_at }}</div>
+        </template>
       </div>
     </div>
     <div v-if="status != 3 && (isAdmin || isWriter || isMember)" class="post">
@@ -67,7 +74,7 @@
   margin: .5rem 0;
 }
 
-.head .body .content { 
+.head .body .content {
   overflow: auto;
 }
 

--- a/ui2/src/components/Issue.vue
+++ b/ui2/src/components/Issue.vue
@@ -38,7 +38,7 @@
           <div class="meta">投稿者: {{ item.member.name }} | {{ item.created_at }}</div>
         </template>
         <template v-else>
-          <div class="meta">投稿者: ICTSC | {{ item.created_at }}</div>
+          <div class="meta">投稿者: ICTSC admin | {{ item.created_at }}</div>
         </template>
       </div>
     </div>

--- a/ui2/src/pages/Issues.vue
+++ b/ui2/src/pages/Issues.vue
@@ -170,10 +170,26 @@ export default {
   },
   methods: {
     firstComment (comments) {
+      // 一番最初に出てきた質問
       return comments[0] || { member: {} };
     },
     lastResponseComment (comments, admin = true) {
-      var notWriterComment = comments.filter(c => (c.member.role_id === 4) !== admin);
+      // 一番最後に返答した質問
+      // その前は特に表示しない
+
+      // 権限不足でmember情報が取れなかった場合に、undefinedになるのでそれを埋める
+      // role_id = 0 は無意味であるはずなのでとりあえず設定している
+      var paddingComment = comments.map(function (element) {
+        if (!element.member) {
+          element.member = {}
+          element.member.role_id = 0;
+          return element;
+        }
+
+        return element;
+      });
+
+      var notWriterComment = paddingComment.filter(c => (c.member.role_id === 4) !== admin);
       if (notWriterComment.length === 0) return {};
       return notWriterComment[notWriterComment.length - 1];
     },

--- a/ui2/src/utils/Filters.js
+++ b/ui2/src/utils/Filters.js
@@ -40,6 +40,9 @@ export function issueStatus (issue) {
   if (issue.comments.length < 2) return 1;
 
   var lastComment = issue.comments[issue.comments.length - 1];
+  // memberが居ない => readableではないユーザ (上位ユーザ)
+  if (!lastComment.member) return 2;
+
   if (lastComment.member.role_id === 4) return 1;
   return 2;
 }


### PR DESCRIPTION
fix #177 

自分よりも上の権限だった場合、readbleでないためAPIリクエストに対して虚無が返答する。

その場合にUI側ではundefinedとなってしまい何も表示されないため、undefinedであった場合は上位ユーザであると仮定してそのようにチェックする実装を行った。