### PR TITLE
Fix/ui

### DIFF
--- a/ui2/src/components/InfoPanel.vue
+++ b/ui2/src/components/InfoPanel.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="panel">
-    <span class="limit">{{ limit | tickDuration }}</span>
+    <span class="limit">{{ limit | tickDuration("HH:mm:ss") }}</span>
     <span v-if="isMember" class="score">
       <span class="label">Progress</span>
       <span class="ratio">{{ ratio }}</span>
@@ -54,7 +54,12 @@ export default {
     limit () {
       var end = this.contest.competition_end_at;
       if (end) {
-        return new Date(end).valueOf() - this.currentDate.valueOf();
+        let duration = new Date(end).valueOf() - this.currentDate.valueOf();
+        if (duration > 0) {
+          return duration;
+        } else {
+          return "Contest has finished";
+        }
       } else {
         return 0
       }

--- a/ui2/src/components/InfoPanel.vue
+++ b/ui2/src/components/InfoPanel.vue
@@ -1,10 +1,6 @@
 <template>
   <div class="panel">
     <span class="limit">{{ limit | tickDuration("HH:mm:ss") }}</span>
-    <span v-if="isMember" class="score">
-      <span class="label">Progress</span>
-      <span class="ratio">{{ ratio }}</span>
-    </span>
   </div>
 </template>
 
@@ -75,7 +71,7 @@ export default {
   watch: {
     problems (val) {
       try {
-        this.sumPurePoint = ((e) => e.perfect_point ? e.perfect_point : 0)(latestAnswer(val))
+        this.sumPurePoint = val.reduce((p, n) => p + n.perfect_point, 0);
 
         var scores = answers => ((e) => e && e.score ? e.score.point : 0)(latestAnswer(answers));
         this.scoredPurePoint = val

--- a/ui2/src/pages/Problems.vue
+++ b/ui2/src/pages/Problems.vue
@@ -567,10 +567,13 @@ export default {
     },
     problemUnlockConditionTitle (id) {
       var found = this.problems.find(p => p.id === id);
-      if (found && found.team_private && found.title) return `「${found.title}」で基準を満たすこと`;
-      if (found && found.title) return `「${found.title}」で基準を満たすチームが表われること`;
-      if (found) return '前の問題で基準を満たすチームが表われること';
-      else return '前の問題';
+      if (found) {
+        let prev = found.title ? `「${found.title}」` : '前の問題';
+        let cond = found.team_private ? '' : 'チームが現れる';
+        return `${prev}で基準を満たす${cond}こと`;
+      } else {
+        return '前の問題';
+      }
     },
     problemGroupIconSrc (problem) {
       let pg = this.problemGroups.find(pg => !pg.visible && pg.problem_ids.includes(problem.id));


### PR DESCRIPTION
未回答問題の点数を `0` -> `---` に変更
一覧画面では `採点中` と表示
スタッフで解答の期限をカウントダウン表示
タイマーのプログレスを削除(芸術点が満点を超えるため)
コンテスト終了後の時間表示を修正