### PR TITLE
remove EXPOSE_*_PORT environments

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,15 +1,6 @@
 TZ=Asia/Tokyo
 RACK_ENV=development
 
-# For docker-compose
-# RedisとDBはdocker-composeが作成する内部ネットワークでアクセスできるのでEXPOSEするポートは適当でいい
-# TODO: まだUI側が環境変数から読み込むようにできてない
-EXPOSE_API_PORT=8900
-EXPOSE_UI_PORT=8901
-EXPOSE_REDIS_PORT=8902
-EXPOSE_DB_PORT=8903
-EXPOSE_PLASMA=8904
-
 MYSQL_HOST=db
 MYSQL_USER=ictsc_score_server
 MYSQL_PASSWORD=ictsc_score_server

--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ Example web server settings are located `ui/h2o.conf`
 $ git clone https://github.com/ictsc/ictsc-score-server.git
 $ cd ictsc-score-server
 $ cp .env{.sample,}
-$ cat .env | grep '^EXPOSE_' >> ~/.bashrc # to execute docker-compose command in not project root directory
 $ # Edit .env
 $ docker-compose build # or pull
 $ docker-compose run --rm api rake db:setup db:seed_fu # if sample data is needed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - redis
     ports:
       # environment: では指定できないので.envで指定する必要がある
-      - "${EXPOSE_API_PORT}:3000"
+      - "8900:3000"
     stdin_open: true
     tty: true
     volumes:
@@ -29,19 +29,19 @@ services:
       - api
       - plasma
     ports:
-      - "${EXPOSE_UI_PORT}:80"
+      - "8901:80"
 
   redis:
     image: redis:4.0.11-alpine
     env_file: .env
     ports:
-      - "${EXPOSE_REDIS_PORT}:6379"
+      - "8902:6379"
 
   db:
     image: mariadb:10.3
     env_file: .env
     ports:
-      - "${EXPOSE_DB_PORT}:3306"
+      - "8903:3306"
     # デバック用に永続化したい場合はコメントアウト
     # volumes:
     #   - "./tmp/db:/var/lib/mysql"
@@ -53,7 +53,7 @@ services:
     depends_on:
       - redis
     ports:
-      - "${EXPOSE_PLASMA}:8080"
+      - "8904:8080"
       # - 50051:50051
 
   yamllint:


### PR DESCRIPTION
プロジェクトのトップ以外でdocker-composeが使えなくなるので廃止