### PR TITLE
Remove view the ID and role from members page

### DIFF
--- a/ui/src/pages/Members.vue
+++ b/ui/src/pages/Members.vue
@@ -4,16 +4,20 @@
     <table class="table table-striped">
       <thead>
         <tr>
+          <th v-if="isAdmin || isWriter">#</th>
           <th>Name</th>
           <th>Login</th>
           <th>TeamID</th>
+          <th v-if="isAdmin || isWriter">Role</th>
         </tr>
       </thead>
       <tbody>
         <tr v-for="member in members">
+          <td v-if="isAdmin || isWriter">{{ member.id }}</td>
           <td>{{ member.name }}</td>
           <td>{{ member.login }}</td>
           <td>{{ member.team ? member.team.name : '--- None ---' }}</td>
+          <td v-if="isAdmin || isWriter">{{ member.role_id }}</td>
         </tr>
       </tbody>
     </table>
@@ -27,6 +31,7 @@
 <script>
 import { SET_TITLE } from '../store/'
 import { API } from '../utils/Api'
+import { mapGetters } from 'vuex'
 
 export default {
   name: 'members',
@@ -40,6 +45,10 @@ export default {
     }
   },
   computed: {
+    ...mapGetters([
+      'isAdmin',
+      'isWriter',
+    ]),
   },
   watch: {
   },

--- a/ui/src/pages/Members.vue
+++ b/ui/src/pages/Members.vue
@@ -4,20 +4,16 @@
     <table class="table table-striped">
       <thead>
         <tr>
-          <th>#</th>
           <th>Name</th>
           <th>Login</th>
           <th>TeamID</th>
-          <th>Role</th>
         </tr>
       </thead>
       <tbody>
         <tr v-for="member in members">
-          <th>{{ member.id }}</th>
           <td>{{ member.name }}</td>
           <td>{{ member.login }}</td>
           <td>{{ member.team ? member.team.name : '--- None ---' }}</td>
-          <td>{{ member.role_id }}</td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
resolve #311

**Overview**
ログインユーザのRoleが `admin` または `writer` 以外の場合、フロントエンドの `/members` ページのメンバー項目の `ID` と `Role` の描画を削除する。

既存
![image](https://user-images.githubusercontent.com/19605052/52894945-c5fdbd80-31f5-11e9-855f-bfc1bda47983.png)

変更後
<img width="705" alt="screen shot 2019-02-16 at 14 19 09" src="https://user-images.githubusercontent.com/19605052/52894947-d877f700-31f5-11e9-9d0a-32cf4095290d.png">


