### PR TITLE
開いた直後にログインしていなければログインフォームへ飛ばす

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -102,14 +102,21 @@ export default {
           } else {
             this.unsubscribeNotification();
 
-            Emit(PUSH_NOTIF, {
-              type: 'error',
-              title: 'セッション情報の取得に失敗しました',
-              detail: '',
-              key: 'login',
-            });
+            const current_page = this.$router.currentRoute.name
+            if (current_page === 'login') {
+              // do nothing
+            } else if (current_page === 'dashboard') {
+              Emit(PUSH_NOTIF, {
+                type: 'info',
+                title: 'セッション情報の取得に失敗しました',
+                detail: '',
+                key: 'login',
+              });
 
-            this.jumpLogin()
+              this.jumpLogin()
+            } else {
+              Emit(AUTH_ERROR)
+            }
           }
         })
         .catch(err => {

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -101,7 +101,15 @@ export default {
             setTimeout(() => this.reloadSession(), 1000 * 60);
           } else {
             this.unsubscribeNotification();
-            Emit(AUTH_ERROR);
+
+            Emit(PUSH_NOTIF, {
+              type: 'error',
+              title: 'セッション情報の取得に失敗しました',
+              detail: '',
+              key: 'login',
+            });
+
+            this.jumpLogin()
           }
         })
         .catch(err => {

--- a/ui/src/components/Notif.vue
+++ b/ui/src/components/Notif.vue
@@ -39,7 +39,7 @@
 </template>
 
 <style scoped>
-.item, .item.item-success {
+.item, .item.item-success, .item.item-info {
   background: #07D8E0;
 }
 .item, .item.item-warn {
@@ -124,7 +124,7 @@ Notifコンポーネントは、EventBusからイベントを受け取り、通�
 ```js
 import { Emit, PUSH_NOTIF } from '../utils/EventBus'
 Emit(PUSH_NOTIF, {
-  type: 'error',  // success/warn/error
+  type: 'error',  // success/info/warn/error
   icon: 'warning',  // fontawsomeのアイコン名
   title: '設定の更新に失敗しました。',  // タイトル
   detail: 'ドメインチェックが失敗したため、サイトを有効にできません。',  // エラー文など
@@ -135,7 +135,7 @@ Emit(PUSH_NOTIF, {
 ```
 
 `autoClose` がtrueの場合、 `timeout` ミリ秒で通知を消します。
-指定がない場合は、 `type` がerror,warnの際はfalse・successの場合はtrueがデフォルトで指定されます。
+指定がない場合は、 `type` がerror,warnの際はfalse・success,infoの場合はtrueがデフォルトで指定されます。
 
 通知を消すサンプルは以下のとおりです。
 
@@ -316,6 +316,11 @@ export default {
         case 'api':
           icon = 'comments';
           autoClose = false;
+          break;
+        case 'info':
+          icon = 'exclamation';
+          autoClose = true;
+          timeout = 3000;
           break;
         default:
         case 'success':


### PR DESCRIPTION
表題の通りです。
初回にトップページを開いたときに、「セッションがない」というエラーを出すのは体験としてあまり良くないのでは? と思ったので、ログインページへ飛ばすようにしてみました。

タイミングの関係上、セッションその他の読み込みが終わらないとリダイレクトされず、ちょっと画面がちらついて気持ち悪いので、微妙かなと思ったらcloseしてください

実際には初回に限った話であればクッキーの有無を見ればいいと思うので、そういう実装にしても良いと思います ( `vue-cookie` 等で判断すれば良い)