### PR TITLE
チーム登録コードのサジェストを復活させる

### DIFF
--- a/api/app/controllers/members_controller.rb
+++ b/api/app/controllers/members_controller.rb
@@ -16,7 +16,7 @@ class MembersController < ApplicationController
     @attrs = params_to_attributes_of(klass: Member, exclude: [:hashed_password], include: [:password])
 
     if !(is_admin? || is_writer?) || params[:registration_code].present?
-      @team = Team.find_by_registration_code(params[:registration_code])
+      @team = Team.find_by(registration_code: params[:registration_code])
       if @team.nil?
         status 400
         next json registration_code: ['を入力してください']

--- a/api/app/controllers/teams_controller.rb
+++ b/api/app/controllers/teams_controller.rb
@@ -1,8 +1,4 @@
-require 'sinatra/crypt_helpers'
-
 class TeamsController < ApplicationController
-  helpers Sinatra::CryptHelpers
-
   before '/api/teams*' do
     I18n.locale = :en if request.xhr?
     halt 404 if !is_admin? && !is_writer? && !Config.in_competition_time?

--- a/api/app/models/team.rb
+++ b/api/app/models/team.rb
@@ -1,14 +1,11 @@
-require 'sinatra/crypt_helpers'
+require 'digest/sha1'
 
 class Team < ApplicationRecord
-  include Sinatra::CryptHelpers
-  extend Sinatra::CryptHelpers
-
   validates :name, presence: true
   validates :organization, presence: false
+  validates :registration_code, presence: true, uniqueness: true
   validates :hashed_registration_code, presence: true
   validates_associated :notification_subscriber
-  validate :validate_registration_code_uniqueness, if: :will_save_change_to_registration_code?
 
   has_many :members, dependent: :destroy
   has_many :answers, dependent: :destroy
@@ -18,39 +15,13 @@ class Team < ApplicationRecord
 
   before_validation :build_notification_subscriber_if_not_exists
 
-  attr_reader :registration_code
+  def registration_code=(value)
+    super(value)
+    self.hashed_registration_code = Digest::SHA1.hexdigest(value)
+  end
 
   def build_notification_subscriber_if_not_exists
     build_notification_subscriber unless notification_subscriber
-  end
-
-  def will_save_change_to_registration_code?
-    new_record? || will_save_change_to_hashed_registration_code?
-  end
-
-  def validate_registration_code_uniqueness
-    if registration_code.blank?
-      errors.add(:registration_code, 'should not be blank')
-      return false
-    end
-
-    if self.class.registration_code_exists?(registration_code)
-      errors.add(:registration_code, 'already exists')
-      return false
-    end
-
-    true
-  end
-
-  def registration_code=(value)
-    return if value.blank? || same_registration_code?(value)
-
-    @registration_code = value
-    self.hashed_registration_code = hash_password(@registration_code)
-  end
-
-  def same_registration_code?(code)
-    hashed_registration_code.present? && compare_password(code, hashed_registration_code)
   end
 
   # method: POST
@@ -88,7 +59,7 @@ class Team < ApplicationRecord
     when ROLE_ID[:admin], ROLE_ID[:writer]
       all_column_names(reference_keys: reference_keys)
     else
-      all_column_names(reference_keys: reference_keys) - %w(hashed_registration_code)
+      all_column_names(reference_keys: reference_keys) - %w(registration_code)
     end
   end
 
@@ -108,14 +79,4 @@ class Team < ApplicationRecord
     readable_records(user: user, action: action)
       .filter_columns(user: user, action: action)
   }
-
-  def self.find_by_registration_code(registration_code)
-    find {|team| compare_password(registration_code, team.hashed_registration_code) }
-  end
-
-  def self.registration_code_exists?(registration_code, ignore: nil)
-    raise ArgumentError, 'registration_code should not be blank' if registration_code.blank?
-
-    Team.pluck(:hashed_registration_code).any? {|hash| compare_password(registration_code, hash) }
-  end
 end

--- a/api/db/fixtures/development/test_data.rb
+++ b/api/db/fixtures/development/test_data.rb
@@ -27,16 +27,16 @@ Config.seed(:key, [
 ])
 
 Team.seed(:id, [
-  { id: 1,  name: 'Team 1',        organization: 'A学校',              hashed_registration_code: hash_password('teama') },
-  { id: 2,  name: 'Team 2',        organization: 'B学校',              hashed_registration_code: hash_password('teamb') },
-  { id: 3,  name: 'Team 3',        organization: 'C学校',              hashed_registration_code: hash_password('teamc') },
-  { id: 4,  name: 'Team 4',        organization: 'D学校',              hashed_registration_code: hash_password('teamd') },
-  { id: 5,  name: 'Team 5',        organization: 'E学校',              hashed_registration_code: hash_password('teame') },
-  { id: 6,  name: 'Team 6',        organization: 'F学校',              hashed_registration_code: hash_password('teamf') },
-  { id: 20, name: 'Daydream Café', organization: 'Rabbit house',       hashed_registration_code: hash_password('pyonpyon') },
-  { id: 21, name: 'fourfolium',    organization: 'イーグルジャンプ',   hashed_registration_code: hash_password('zoi') },
-  { id: 22, name: "\u{1F338}",     organization: 'ロゴが変わった会社', hashed_registration_code: hash_password('sakura') },
-  { id: 23, name: 'らびりんず',    organization: '棗屋',               hashed_registration_code: hash_password('kurou') },
+  { id: 1,  name: 'Team 1',        organization: 'A学校',              registration_code: 'teama' },
+  { id: 2,  name: 'Team 2',        organization: 'B学校',              registration_code: 'teamb' },
+  { id: 3,  name: 'Team 3',        organization: 'C学校',              registration_code: 'teamc' },
+  { id: 4,  name: 'Team 4',        organization: 'D学校',              registration_code: 'teamd' },
+  { id: 5,  name: 'Team 5',        organization: 'E学校',              registration_code: 'teame' },
+  { id: 6,  name: 'Team 6',        organization: 'F学校',              registration_code: 'teamf' },
+  { id: 20, name: 'Daydream Café', organization: 'Rabbit house',       registration_code: 'pyonpyon' },
+  { id: 21, name: 'fourfolium',    organization: 'イーグルジャンプ',   registration_code: 'zoi' },
+  { id: 22, name: "\u{1F338}",     organization: 'ロゴが変わった会社', registration_code: 'sakura' },
+  { id: 23, name: 'らびりんず',    organization: '棗屋',               registration_code: 'kurou' },
 ])
 
 Member.seed(:login, [

--- a/api/db/migrate/20190228165051_add_team_registration_code_again.rb
+++ b/api/db/migrate/20190228165051_add_team_registration_code_again.rb
@@ -1,0 +1,5 @@
+class AddTeamRegistrationCodeAgain < ActiveRecord::Migration[5.2]
+  def change
+  	add_column :teams, :registration_code, :string, null: false
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_19_194031) do
+ActiveRecord::Schema.define(version: 2019_02_28_165051) do
 
   create_table "answers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "text", limit: 4095, null: false
@@ -167,10 +167,10 @@ ActiveRecord::Schema.define(version: 2019_02_19_194031) do
   create_table "teams", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.string "organization"
-    t.string "hashed_registration_code", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["hashed_registration_code"], name: "index_teams_on_hashed_registration_code", unique: true
+    t.string "hashed_registration_code", null: false
+    t.string "registration_code", null: false
   end
 
 end

--- a/api/spec/factories/teams.rb
+++ b/api/spec/factories/teams.rb
@@ -1,9 +1,10 @@
-require 'sinatra/crypt_helpers'
+require 'digest/sha1'
 
 FactoryBot.define do
   factory :team do
     sequence(:name) {|n| "team_#{n}" }
     organization { "organization_of_#{name}" }
     registration_code { "#{name}_registration_code" }
+    hashed_registration_code { Digest::SHA1.hexdigest("#{name}_registration_code") }
   end
 end

--- a/api/spec/requests/teams_spec.rb
+++ b/api/spec/requests/teams_spec.rb
@@ -63,19 +63,19 @@ describe 'Teams' do
     end
 
     describe '#keys' do
-      let(:expected_keys) { %w(id name organization created_at updated_at) }
+      let(:expected_keys) { %w(id name organization created_at updated_at hashed_registration_code) }
       subject { json_response.keys }
       by_nologin     { is_expected.to match_array expected_keys }
       by_viewer      { is_expected.to match_array expected_keys }
       by_participant { is_expected.to match_array expected_keys }
-      by_writer      { is_expected.to match_array expected_keys + %w(hashed_registration_code) }
-      by_admin       { is_expected.to match_array expected_keys + %w(hashed_registration_code) }
+      by_writer      { is_expected.to match_array expected_keys + %w(registration_code) }
+      by_admin       { is_expected.to match_array expected_keys + %w(registration_code) }
     end
   end
 
   describe 'POST /api/teams' do
     let(:team) { build(:team) }
-    let(:post_response_keys) { %w(id name organization created_at updated_at hashed_registration_code) }
+    let(:post_response_keys) { %w(id name organization created_at updated_at registration_code hashed_registration_code) }
 
     let(:params) do
       {

--- a/ui/src/pages/Login.vue
+++ b/ui/src/pages/Login.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-loading="asyncLoading">
     <div class="row justify-content-center">
-      <div class="col-4">
+      <div class="col-6">
         <h1>サインイン</h1>
         <form v-on:submit.prevent="submit()">
           <div class="form-group">

--- a/ui/src/pages/Signup.vue
+++ b/ui/src/pages/Signup.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div class="row justify-content-center">
-      <div class="col-4">
+      <div class="col-6">
         <h1>サインアップ</h1>
         <div class="form-group">
           <label for="input-name">氏名</label>
@@ -22,9 +22,19 @@
           >
         </div>
         <div class="form-group">
-          <label for="input-org">所属とチーム</label>
+          <label for="input-organization">所属</label>
           <input
-            id="input-org"
+            id="input-organization"
+            :value="organizationName"
+            type="text"
+            class="form-control form-control-lg"
+            readonly
+          >
+        </div>
+        <div class="form-group">
+          <label for="input-team">チーム名</label>
+          <input
+            id="input-team"
             :value="teamName"
             type="text"
             class="form-control form-control-lg"
@@ -89,6 +99,11 @@ export default {
     }
   },
   computed: {
+    organizationName () {
+      var team = this.teams.find(t => t.hashed_registration_code === sha1(this.registration_code));
+      if (team) return team.organization;
+      else return '-----';
+    },
     teamName () {
       var team = this.teams.find(t => t.hashed_registration_code === sha1(this.registration_code));
       if (team) return team.name;


### PR DESCRIPTION
Closes #412, #413

- `teams` に `registration_code` カラムを再度追加しました。
  - 特に大きな変更はないです
- UI がチーム名しか表示していなかったので、所属も表示するように修正しました
- フォームの幅を少し広げました (このPRから外したほうが良ければ外します)