### PR TITLE
make dummy data

### DIFF
--- a/api/.rubocop.yml
+++ b/api/.rubocop.yml
@@ -30,6 +30,7 @@ Metrics/BlockLength:
   Max: 20
   Exclude:
     - 'spec/**/*_spec.rb'
+    - 'spec/factories/*.rb'
 Metrics/LineLength:
   # 基本的に長い行の折返しはエディターで対処
   Enabled: false

--- a/api/app/graphql/mutations/apply_score.rb
+++ b/api/app/graphql/mutations/apply_score.rb
@@ -14,7 +14,7 @@ module Mutations
       Acl.permit!(mutation: self, args: {})
 
       # grade!でscoreレコードが作られる
-      if answer.grade!(point: point, solved: solved)
+      if answer.grade(point: point, solved: solved)
         { score: answer.score.readable, errors: [] }
       else
         { errors: answer.score.errors.full_messages }

--- a/api/app/models/score.rb
+++ b/api/app/models/score.rb
@@ -2,15 +2,15 @@
 
 class Score < ApplicationRecord
   # nil or 得点率
-  validates :point,  presence: false, length: { minimum: 0, maximum: 100 }
+  validates :point,  presence: false, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 100 }
   validates :solved, boolean: true
-  validates :answer, presence: true, uniqueness: { scope: %i[team_id created_at] }
+  validates :answer, presence: true, uniqueness: true
 
   belongs_to :answer
   has_one :team, through: :answer
   has_one :problem, through: :answer
 
-  after_save :refresh_first_correct_answer, if: :saved_change_to_correct?
+  after_save :refresh_first_correct_answer, if: :saved_change_to_solved?
 
   def refresh_first_correct_answer
     # TODO: 親トランザクションやらなんやらが影響しそう after_commitにするのはうかつ

--- a/api/spec/factories/answer.rb
+++ b/api/spec/factories/answer.rb
@@ -2,12 +2,23 @@
 
 FactoryBot.define do
   factory :answer do
-    # mode {  }
-    sequence(:bodies) {|_n| '' } # type: :json, null: false
-    sequence(:created_at) {|n| Time.current + n.second } # type: :datetime, null: false
-    sequence(:updated_at) {|n| Time.current + n.second } # type: :datetime, null: false
-    # association :problem # optional: nil
-    # association :team # optional: nil
+    # unique制約から逃れるため適当にずらす
+    created_at { Time.current + Random.rand(60).minutes + Random.rand(60).seconds }
+    updated_at { created_at }
+    confirming { Random.rand(2).odd? }
+    bodies do
+      case problem.body.mode
+      when 'textbox'
+        [[Faker::Books::Dune.quote]]
+      when 'radio_button'
+        problem.body.candidates.map {|c| [c.sample] }
+      when 'checkbox'
+        problem.body.candidates.map {|c| c.sample(Random.rand(1..c.size)) }
+      end
+    end
+
+    problem { nil }
+    team { nil }
     # association :first_correct_answer # optional: nil
   end
 end

--- a/api/spec/factories/category.rb
+++ b/api/spec/factories/category.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  code_begin = +'AAA'
+
+  factory :category do
+    code do
+      code = -code_begin
+      code_begin.next!
+      code
+    end
+    sequence(:title) {|i| "グループ#{i}" }
+    description { Faker::Books::Dune.saying }
+    order { Random.rand(10..1000) }
+
+    # has_many problems
+  end
+end

--- a/api/spec/factories/notice.rb
+++ b/api/spec/factories/notice.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :notice do
+    title { Faker::Book.title }
+    text { Array.new(Random.rand(1..3)) { Faker::Books::Dune.quote }.join("\n") }
+    pinned { Random.rand(2).odd? }
+    target_team { nil }
+  end
+end

--- a/api/spec/factories/problem.rb
+++ b/api/spec/factories/problem.rb
@@ -14,9 +14,17 @@ FactoryBot.define do
     order { Random.rand(1000) }
     team_isolate { false }
     open_at { nil }
-
     category { nil }
-    association :body, factory: :problem_body
+
+    transient do
+      mode { :textbox }
+    end
+
+    callback(:after_build, :after_stub) do |problem, evaluator|
+      # callbackで作らないとcreateが失敗する
+      problem.body ||= build(:problem_body, evaluator.mode.to_sym)
+    end
+
     # association :environments, :problem_environment # optional: nil
     # association :supplements, factory: :problem_supplement # optional: nil
     # association :category # optional: true
@@ -25,21 +33,5 @@ FactoryBot.define do
     # association :answers # optional: nil
     # association :issues # optional: nil
     # association :first_correct_answers # optional: nil
-
-    trait :mode_textbox do
-      association :body, :textbox, factory: :problem_body
-    end
-
-    trait :mode_radio_button do
-      association :body, :radio_button, factory: :problem_body
-    end
-
-    trait :mode_checkbox do
-      association :body, :checkbox, factory: :problem_body
-    end
-
-    trait :team_isolate do
-      team_isolate { true }
-    end
   end
 end

--- a/api/spec/factories/problem.rb
+++ b/api/spec/factories/problem.rb
@@ -1,15 +1,22 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :problem do
-    sequence(:code) {|n| "%<name>s #{n}" } # type: :string, null: false
-    sequence(:writer) {|n| "%<name>s #{n}" } # type: :string, null: true
-    sequence(:secret_text) {|n| "%<name>s #{n}" } # type: :string, null: false, default: ""
-    sequence(:order) {|n| n } # type: :integer, null: false
-    sequence(:team_isolate, &:odd?) # type: :boolean, null: false, default: "false"
-    open_at { nil } # type: :tsrange, null: true
+  code_begin = +'AAA'
 
-    # association :body, factory: :problem_body # optional: nil
+  factory :problem do
+    code do
+      code = -code_begin
+      code_begin.next!
+      code
+    end
+    writer { Faker::Book.author }
+    secret_text { Faker::Books::Dune.planet }
+    order { Random.rand(1000) }
+    team_isolate { false }
+    open_at { nil }
+
+    category { nil }
+    association :body, factory: :problem_body
     # association :environments, :problem_environment # optional: nil
     # association :supplements, factory: :problem_supplement # optional: nil
     # association :category # optional: true
@@ -18,5 +25,21 @@ FactoryBot.define do
     # association :answers # optional: nil
     # association :issues # optional: nil
     # association :first_correct_answers # optional: nil
+
+    trait :mode_textbox do
+      association :body, :textbox, factory: :problem_body
+    end
+
+    trait :mode_radio_button do
+      association :body, :radio_button, factory: :problem_body
+    end
+
+    trait :mode_checkbox do
+      association :body, :checkbox, factory: :problem_body
+    end
+
+    trait :team_isolate do
+      team_isolate { true }
+    end
   end
 end

--- a/api/spec/factories/problem_body.rb
+++ b/api/spec/factories/problem_body.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  gen_cand = proc { Array.new(Random.rand(2..7)) { Faker::Coffee.blend_name }.uniq }
+
+  factory :problem_body do
+    mode { 'textbox' }
+    title { Faker::Book.title }
+    text { Array.new(Random.rand(4..10)) { Faker::Books::Dune.quote }.join("\n") }
+    perfect_point { Random.rand(10..1000) }
+    problem { nil }
+
+    transient do
+      candidates_count { Random.rand(1..5) }
+    end
+
+    trait :textbox do
+      mode { 'textbox' }
+    end
+
+    trait :radio_button do
+      mode { 'radio_button' }
+      candidates { Array.new(candidates_count) { gen_cand.call } }
+      corrects { candidates.map {|c| c.sample(1) } }
+    end
+
+    trait :checkbox do
+      mode { 'checkbox' }
+      candidates { Array.new(candidates_count) { gen_cand.call } }
+      corrects { candidates.map {|c| c.sample(Random.rand(1..c.size)) } }
+    end
+  end
+end

--- a/api/spec/factories/problem_environment.rb
+++ b/api/spec/factories/problem_environment.rb
@@ -6,5 +6,7 @@ FactoryBot.define do
     sequence(:host) {|n| "host#{n}.local" }
     sequence(:user) {|n| "user#{n}" }
     sequence(:password) {|n| "password#{n}" }
+    team { nil }
+    problem { nil }
   end
 end

--- a/api/spec/factories/problem_supplement.rb
+++ b/api/spec/factories/problem_supplement.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :problem_supplement do
-    sequence(:text) {|n| "%<name>s #{n}" } # type: :string, null: false
-    # association :problem # optional: nil
+    text { Array.new(Random.rand(1..2)) { Faker::Books::Dune.quote }.join("\n") }
+    problem { nil }
   end
 end

--- a/api/spec/factories/score.rb
+++ b/api/spec/factories/score.rb
@@ -2,8 +2,8 @@
 
 FactoryBot.define do
   factory :score do
-    point { Random.rand(0..100) } # type: :integer, null: false
-    sequence(:solved, &:odd?) # type: :boolean, null: false, default: "false"
-    association :answer # optional: nil
+    point { Random.rand(0..100) }
+    sequence(:solved, &:odd?)
+    answer { nil }
   end
 end

--- a/api/spec/factories/team.rb
+++ b/api/spec/factories/team.rb
@@ -1,23 +1,28 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
+  alphabets = ('a'..'zz').to_a.freeze
+
   factory :team do
-    sequence(:name) {|n| "team #{n}" } # type: :string, null: false
-    sequence(:password) {|n| "team #{n}" } # type: :string, null: false
-    sequence(:organization) {|n| "team #{n}" } # type: :string, null: true
+    name { "team #{alphabets[number - 1]}" }
+    password { name }
+    organization { "Org. #{name}" }
     sequence(:number) {|n| n }
 
     trait :staff do
+      name { "staff #{alphabets[number - 1]}" }
       role { :staff }
     end
 
     trait :audience do
-      role { :player }
+      name { "audience #{alphabets[number - 1]}" }
+      role { :audience }
     end
 
     trait :player do
+      name { "team #{alphabets[number - 1]}" }
       role { :player }
-      color { '#996633' }
+      color { Faker::Color.hex_color }
     end
 
     # association :answers # optional: nil


### PR DESCRIPTION
開発・検証用ダミーデータをたくさん作った。     
解答やスコアのレコード数は一定の基準をベースに乱数で上下する。
そこそこ現実的な設定にしたつもりだったが、解答数2500は多すぎる気がする :smile: 
`rails db:setup` に20秒かかる。  
IssueやAttachmentのデータは未作成。   

```
Team.count 72
Notice.count 29
Category.count 10
Problem.count 50
Answer.count 2486
Score.count 1657
ProblemSupplement.count 22
ProblemEnvironment.count 700
```